### PR TITLE
Don't throw a TypeError slicing unsorted results, fixes #6

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,7 @@ CHANGES
 2.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Don't throw a TypeError slicing unsorted results, fixes #6
 
 2.3 (2017-04-26)
 ----------------

--- a/src/hurry/query/query.py
+++ b/src/hurry/query/query.py
@@ -286,8 +286,9 @@ class Query(object):
                 selected_results = reversed(selected_results)
                 is_iterator = True
             if limit or start:
+                slice_end = limit and start + limit or None
                 selected_results = itertools.islice(
-                    selected_results, start, start + limit)
+                    selected_results, start, slice_end)
                 is_iterator = True
 
         if is_iterator:

--- a/src/hurry/query/query.txt
+++ b/src/hurry/query/query.txt
@@ -547,6 +547,14 @@ the tested index is deterministic enough to be used as a proper test).
   [1, 2]
 
   >>> f1 = ('catalog1', 'f1')
+  >>> displayResult(Eq(f1, 'a'), start=1)
+  [2, 6]
+
+  >>> f1 = ('catalog1', 'f1')
+  >>> displayResult(Eq(f1, 'a'), start=1, limit=1)
+  [2]
+
+  >>> f1 = ('catalog1', 'f1')
   >>> displayResult(Eq(f1, 'a'), limit=2, reverse=True)
   [6, 2]
 


### PR DESCRIPTION
Fixes https://github.com/zopefoundation/hurry.query/issues/6