### PR TITLE
Drop support for pkg_resources namespace and replace it with PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 CHANGES
 =======
 
-4.1 (unreleased)
+5.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ CHANGES
 5.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Drop support for pkg_resources namespace and replace it with PEP 420 native namespace.
 
 
 4.0 (2023-05-04)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ tests_require = [
 
 setup(
     name="hurry.query",
-    version='4.1.dev0',
+    version='5.0.dev0',
     author='Infrae',
     author_email='zope-dev@zope.dev',
     description="Higher level query system for zope.catalog.",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 import html
 import os
 
-from setuptools import find_packages
+from setuptools import find_namespace_packages
 from setuptools import setup
 
 
@@ -61,9 +61,8 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: Zope :: 3',
     ],
-    packages=find_packages('src'),
+    packages=find_namespace_packages('src'),
     package_dir={'': 'src'},
-    namespace_packages=['hurry'],
     package_data={
         '': ['*.txt', '*.zcml'],
     },

--- a/src/hurry/__init__.py
+++ b/src/hurry/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
Built using https://github.com/zopefoundation/meta/pull/303